### PR TITLE
chore: Update checkout and node versions to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       - ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
Update checkout and node versions to v4: https://hostingers.atlassian.net/browse/AUTO-3944